### PR TITLE
マッチする単語を変更

### DIFF
--- a/ArigatouApp/Presenter/SpeechPresenter.swift
+++ b/ArigatouApp/Presenter/SpeechPresenter.swift
@@ -24,7 +24,7 @@ class SpeechPresenter{
     private var recognitionTask: SFSpeechRecognitionTask?
     private var audioEngine = AVAudioEngine()
     
-    private let WORD = "ありがと"
+    private let WORD = "ありがとう"
     private var previousTranscription = ""
     private var matchCountManger: MatchCountManager!
     


### PR DESCRIPTION
### 問題点
「ありがとう」と発話すると、
「ありがと」と
「ありがとう」
で２回カウントされてしまう。

### 原因
カウント対象の単語は、「ありがと」としていたため。

### 経緯
「ありがとう」は当然カウントするが、「ありがと」と発話されてもカウントするようにしていた。
「ありがと」と発話時に１カウント、「ありがとう」の場合も１カウントとする仕様だった。

### 対処
両方の単語をSFSpeachのライブラリ使う上では無理そう。

「ありがと」はカウント対象にせず、「ありがとう」だけにする事に変更。

