### PR TITLE
マイク利用許可確認アラート周りの変更

### DIFF
--- a/ArigatouApp/Presenter/SpeechPresenter.swift
+++ b/ArigatouApp/Presenter/SpeechPresenter.swift
@@ -173,9 +173,7 @@ extension SpeechPresenter: PresenterInput {
             } else {
                 // 10秒ごとにアラート表示
                 Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
-                    DispatchQueue.main.async {
-                        self.view?.showDeniedSpeechAuthorizeAlert()
-                    }
+                    self.view?.showDeniedSpeechAuthorizeAlert()
                 }
             }
         }

--- a/ArigatouApp/Presenter/SpeechPresenter.swift
+++ b/ArigatouApp/Presenter/SpeechPresenter.swift
@@ -174,8 +174,8 @@ extension SpeechPresenter: PresenterInput {
                 // 起動時に１回表示
                 self.view?.showDeniedSpeechAuthorizeAlert()
                 
-                // その後は10秒ごとにアラート表示
-                Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
+                // その後は５秒おきにアラート表示
+                Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
                     self.view?.showDeniedSpeechAuthorizeAlert()
                 }
             }

--- a/ArigatouApp/Presenter/SpeechPresenter.swift
+++ b/ArigatouApp/Presenter/SpeechPresenter.swift
@@ -171,7 +171,10 @@ extension SpeechPresenter: PresenterInput {
                 }
                 self.startTimer()
             } else {
-                // 10秒ごとにアラート表示
+                // 起動時に１回表示
+                self.view?.showDeniedSpeechAuthorizeAlert()
+                
+                // その後は10秒ごとにアラート表示
                 Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
                     self.view?.showDeniedSpeechAuthorizeAlert()
                 }

--- a/ArigatouApp/View/ViewController.swift
+++ b/ArigatouApp/View/ViewController.swift
@@ -149,11 +149,17 @@ extension ViewController: PresenterOutput{
     }
     
     func showDeniedSpeechAuthorizeAlert(){
-        let alert = UIAlertController(title: "ありがとう100万回", message: "アプリを開始するにはマイクと音声認識へのアクセスを許可してください。", preferredStyle: .alert)
-        let ok = UIAlertAction(title: "OK", style: .default)
+        let alert = UIAlertController(title: "ありがとう100万回", message: "開始するにはマイクと音声認識へのアクセスを許可してください。", preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "キャンセル", style: .default)
+        alert.addAction(cancel)
+        
+        let ok = UIAlertAction(title: "OK", style: .default) { (action) in
+            let url = URL(string: UIApplication.openSettingsURLString)!
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        alert.addAction(ok)
         
         DispatchQueue.main.async {
-            alert.addAction(ok)
             self.present(alert, animated: true, completion: nil)
         }
     }

--- a/ArigatouApp/View/ViewController.swift
+++ b/ArigatouApp/View/ViewController.swift
@@ -149,7 +149,7 @@ extension ViewController: PresenterOutput{
     }
     
     func showDeniedSpeechAuthorizeAlert(){
-        let alert = UIAlertController(title: "ありがとうアプリ", message: "マイクの使用許可がないためアプリを終了します。\nアプリをはじめるには「設定」→「ありがとうアプリ」→音声認識をONにしてください。", preferredStyle: .alert)
+        let alert = UIAlertController(title: "ありがとう100万回", message: "アプリを開始するにはマイクと音声認識へのアクセスを許可してください。", preferredStyle: .alert)
         let ok = UIAlertAction(title: "OK", style: .default)
         
         DispatchQueue.main.async {

--- a/ArigatouApp/View/ViewController.swift
+++ b/ArigatouApp/View/ViewController.swift
@@ -151,8 +151,11 @@ extension ViewController: PresenterOutput{
     func showDeniedSpeechAuthorizeAlert(){
         let alert = UIAlertController(title: "ありがとうアプリ", message: "マイクの使用許可がないためアプリを終了します。\nアプリをはじめるには「設定」→「ありがとうアプリ」→音声認識をONにしてください。", preferredStyle: .alert)
         let ok = UIAlertAction(title: "OK", style: .default)
-        alert.addAction(ok)
-        self.present(alert, animated: true, completion: nil)
+        
+        DispatchQueue.main.async {
+            alert.addAction(ok)
+            self.present(alert, animated: true, completion: nil)
+        }
     }
 }
 


### PR DESCRIPTION
以下を修正

・アプリ起動時、利用許可ない場合ただちにアラート表示
・アラートのタイマーを１０秒ごと→５秒ごとに変更
・アラートにOKだけでなく、キャンセルを追加
・アラートでOKクリック→設定画面を開くようにした
・アラートでキャンセルクリック→アラートが閉じるようにした