### PR TITLE
airgatouApp_device_provisioning_profileをプロジェクトに追加する際、add targetにチェック

### DIFF
--- a/ArigatouApp.xcodeproj/project.pbxproj
+++ b/ArigatouApp.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		CC55BFFE2BCF93C3003C3E15 /* cosmos-640.jpg in Resources */ = {isa = PBXBuildFile; fileRef = CC55BFFD2BCF93C3003C3E15 /* cosmos-640.jpg */; };
 		CC55C0002BCF96D3003C3E15 /* cosmos-1920.jpg in Resources */ = {isa = PBXBuildFile; fileRef = CC55BFFF2BCF96D3003C3E15 /* cosmos-1920.jpg */; };
 		CCDEAD292BDB1CCE0096704A /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDEAD282BDB1CCE0096704A /* LoginViewController.swift */; };
+		CCDEADC82BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision in Resources */ = {isa = PBXBuildFile; fileRef = CCDEADC72BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision */; };
+		CCDEADC92BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision in Resources */ = {isa = PBXBuildFile; fileRef = CCDEADC72BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,7 +53,7 @@
 		CC55BFFD2BCF93C3003C3E15 /* cosmos-640.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "cosmos-640.jpg"; sourceTree = "<group>"; };
 		CC55BFFF2BCF96D3003C3E15 /* cosmos-1920.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "cosmos-1920.jpg"; sourceTree = "<group>"; };
 		CCDEAD282BDB1CCE0096704A /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
-		CCDEADC32BE1EF670096704A /* airgatouApp_device_provisioning_profile.mobileprovision */ = {isa = PBXFileReference; lastKnownFileType = file; path = airgatouApp_device_provisioning_profile.mobileprovision; sourceTree = "<group>"; };
+		CCDEADC72BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision */ = {isa = PBXFileReference; lastKnownFileType = file; path = airgatouApp_device_provisioning_profile.mobileprovision; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,7 +88,7 @@
 		CC55BF432BC9028D003C3E15 = {
 			isa = PBXGroup;
 			children = (
-				CCDEADC32BE1EF670096704A /* airgatouApp_device_provisioning_profile.mobileprovision */,
+				CCDEADC72BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision */,
 				CC55BF4E2BC9028D003C3E15 /* ArigatouApp */,
 				CC55BFF52BCE9C2D003C3E15 /* ArigatouAppTests */,
 				CC55BF4D2BC9028D003C3E15 /* Products */,
@@ -237,6 +239,7 @@
 				CC55BF592BC9028E003C3E15 /* Assets.xcassets in Resources */,
 				CC55BFFE2BCF93C3003C3E15 /* cosmos-640.jpg in Resources */,
 				CC55C0002BCF96D3003C3E15 /* cosmos-1920.jpg in Resources */,
+				CCDEADC82BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -244,6 +247,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CCDEADC92BE1F9050096704A /* airgatouApp_device_provisioning_profile.mobileprovision in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
github actionsエラー対応

ドラッグ・アンド・ドロップ時にチェックを入れてなかった
ここにチェックを入れてみた

<img width="403" alt="スクリーンショット 2024-05-01 13 16 41" src="https://github.com/simazo/ArigatouApp/assets/26078454/85482a56-7b2d-48a6-b8aa-3f6ed3649f78">
