### PR TITLE
code signing identity変更

### DIFF
--- a/ArigatouApp.xcodeproj/project.pbxproj
+++ b/ArigatouApp.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "Apple Development: futoshi tanaka (HJ4P3RH3ZB)";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = P4V2PFCQ2W;
@@ -455,7 +455,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "Apple Development: futoshi tanaka (HJ4P3RH3ZB)";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = P4V2PFCQ2W;


### PR DESCRIPTION
github actionsの以下のエラー対応

```
ArigatouApp has conflicting provisioning settings. ArigatouApp is automatically signed, but code signing identity Apple Development: futoshi tanaka (HJ4P3RH3ZB) has been manually specified. Set the code signing identity value to "Apple Development" in the build settings editor, or switch to manual signing in the Signing & Capabilities editor.
	/Users/runner/Library/Developer/Xcode/DerivedData/ArigatouApp-dvipotvvpjrhvqbjsrlxzssxrypi/Logs/Test/Test-ArigatouApp-2024.05.01_04-18-28-+0000.xcresult
	Testing cancelled because the build failed.
```

変更箇所
<img width="761" alt="スクリーンショット 2024-05-01 13 38 31" src="https://github.com/simazo/ArigatouApp/assets/26078454/b62c3057-e1e2-4bed-ac2d-68a8583dd444">

