### PR TITLE
plist差し替え

### DIFF
--- a/ArigatouApp.xcodeproj/project.pbxproj
+++ b/ArigatouApp.xcodeproj/project.pbxproj
@@ -31,11 +31,12 @@
 		CCDEAE202BE866270096704A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CCDEAE1F2BE866270096704A /* FirebaseAuth */; };
 		CCDEAE222BE866270096704A /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CCDEAE212BE866270096704A /* FirebaseFirestore */; };
 		CCDEAE242BE89D430096704A /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CCDEAE232BE89D430096704A /* FirebaseFirestoreSwift */; };
-		CCDEAE262BE89E040096704A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CCDEAE252BE89E040096704A /* GoogleService-Info.plist */; };
 		CCFB7DD52BED9C1300C4617A /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFB7DD42BED9C1300C4617A /* AuthManager.swift */; };
 		CCFB7DD72BF17A8300C4617A /* VideoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFB7DD62BF17A8300C4617A /* VideoList.swift */; };
 		CCFB7E142BF18D6F00C4617A /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFB7E132BF18D6F00C4617A /* NetworkManager.swift */; };
 		CCFB7E162BF1B54D00C4617A /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = CCFB7E152BF1B54D00C4617A /* icon.png */; };
+		CCFB7E372BF9EBF600C4617A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CCFB7E362BF9EBF600C4617A /* GoogleService-Info.plist */; };
+		CCFB7E382BF9EBF600C4617A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CCFB7E362BF9EBF600C4617A /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,11 +73,11 @@
 		CCDEAE142BE514630096704A /* NaviMenuTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaviMenuTableView.swift; sourceTree = "<group>"; };
 		CCDEAE162BE6BD350096704A /* Validator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validator.swift; sourceTree = "<group>"; };
 		CCDEAE182BE6BE330096704A /* LoginPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPresenter.swift; sourceTree = "<group>"; };
-		CCDEAE252BE89E040096704A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		CCFB7DD42BED9C1300C4617A /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		CCFB7DD62BF17A8300C4617A /* VideoList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoList.swift; sourceTree = "<group>"; };
 		CCFB7E132BF18D6F00C4617A /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		CCFB7E152BF1B54D00C4617A /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
+		CCFB7E362BF9EBF600C4617A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,7 +121,7 @@
 			children = (
 				CCAA463A2BEC99AA00FBF22D /* Develop_Provisioning_Profile.mobileprovision */,
 				CCDEADCD2BE224ED0096704A /* AppStore_ProvisioningProfile.mobileprovision */,
-				CCDEAE252BE89E040096704A /* GoogleService-Info.plist */,
+				CCFB7E362BF9EBF600C4617A /* GoogleService-Info.plist */,
 				CC55BF4E2BC9028D003C3E15 /* ArigatouApp */,
 				CC55BFF52BCE9C2D003C3E15 /* ArigatouAppTests */,
 				CC55BF4D2BC9028D003C3E15 /* Products */,
@@ -280,12 +281,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				CC55BF5C2BC9028E003C3E15 /* LaunchScreen.storyboard in Resources */,
+				CCFB7E372BF9EBF600C4617A /* GoogleService-Info.plist in Resources */,
 				CC55BF592BC9028E003C3E15 /* Assets.xcassets in Resources */,
 				CC55BFFE2BCF93C3003C3E15 /* cosmos-640.jpg in Resources */,
 				CCAA463B2BEC99AA00FBF22D /* Develop_Provisioning_Profile.mobileprovision in Resources */,
 				CCDEADCE2BE224ED0096704A /* AppStore_ProvisioningProfile.mobileprovision in Resources */,
 				CC55C0002BCF96D3003C3E15 /* cosmos-1920.jpg in Resources */,
-				CCDEAE262BE89E040096704A /* GoogleService-Info.plist in Resources */,
 				CCFB7E162BF1B54D00C4617A /* icon.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -295,6 +296,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CCAA463C2BEC99AA00FBF22D /* Develop_Provisioning_Profile.mobileprovision in Resources */,
+				CCFB7E382BF9EBF600C4617A /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GoogleService-Info.plist
+++ b/GoogleService-Info.plist
@@ -3,17 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyCMqyMFH8D5FrMiQe0IIg9eNNqy9sWs7zc</string>
+	<string>AIzaSyDTFcx-GQv-V6e4niFVvNtOGND0NaAINJQ</string>
 	<key>GCM_SENDER_ID</key>
-	<string>14144596789</string>
+	<string>688464473883</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.tanaka.FirebaseAuthMVP</string>
+	<string>com.tanaka.ArigatouApp</string>
 	<key>PROJECT_ID</key>
-	<string>arigatou-app</string>
+	<string>arigatou-app-191c6</string>
 	<key>STORAGE_BUCKET</key>
-	<string>arigatou-app.appspot.com</string>
+	<string>arigatou-app-191c6.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:14144596789:ios:6528badb3bb5e7b5e13a7c</string>
+	<string>1:688464473883:ios:7213711be6fb6be8f0edbe</string>
 </dict>
 </plist>


### PR DESCRIPTION
コンソールに以下のエラーが出てシュミレータが起動できなくった。
新しくplistを作って差し替え。

```
10.25.0 - [FirebaseCore][I-COR000008] The project's Bundle ID is inconsistent with either the Bundle ID in 'GoogleService-Info.plist', or the Bundle ID in the options if you are using a customized options. To ensure that everything can be configured correctly, you may need to make the Bundle IDs consistent. To continue with this plist file, you may change your app's bundle identifier to 'com.tanaka.FirebaseAuthMVP'. Or you can download a new configuration file that matches your bundle identifier from https://console.firebase.google.com/ and replace the current one.
```