### PR TITLE
【Github Actionsエラー対応】デバッグ出力追加

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,12 +17,16 @@ jobs:
 
       - name: Install CocoaPods
         run: |
+          echo "Installing CocoaPods..."
           sudo gem install cocoapods
+          echo "CocoaPods version:"
           pod --version
 
       - name: Install Pods
         run: |
+          echo "pod install..."
           pod install
+          echo "ls Pods:"
           ls -l Pods
 
       - name: Install the Apple certificate and provisioning profile
@@ -58,8 +62,11 @@ jobs:
 
       - name: UnitTests
         #run: xcodebuild test -project ArigatouApp.xcodeproj -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,id=00008110-000664DA0EA0401E,OS=17.4.1' -allowProvisioningUpdates
-        run: xcodebuild
-          -scheme ArigatouApp
-          -sdk iphonesimulator
-          -destination 'platform=iOS Simulator,name=iPhone 15,OS=15.3.0'
+        run: |
+          xcodebuild test \
+          -project ArigatouApp.xcodeproj \
+          -scheme ArigatouApp \
+          -sdk iphonesimulator \
+          -destination 'platform=iOS Simulator,name=iPhone 15,OS=15.3.0' \
+          -allowProvisioningUpdates
           


### PR DESCRIPTION
ログが多すぎてpodインストールが成功したかどうかが確認できない
なのでコメント出力追加