### PR TITLE
【Github Actionsエラー対応】シミュレータのバージョンをデプロイメントターゲットのバージョンと合うよう変更

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -58,5 +58,4 @@ jobs:
       - name: UnitTests
         #run: xcodebuild test -project ArigatouApp.xcodeproj -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,id=00008110-000664DA0EA0401E,OS=17.4.1' -allowProvisioningUpdates
         #run: xcodebuild test -workspace ArigatouApp.xcworkspace -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15,OS=15.3.0'
-        run: xcodebuild test -workspace ArigatouApp.xcworkspace -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.0.1'
-        
+        run: xcodebuild test -workspace ArigatouApp.xcworkspace -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.2'


### PR DESCRIPTION
17.0.1→17.2に変更