### PR TITLE
【Github Actionsエラー対応】DateFormatterの設定が上書きされないよう修正＆CIでのシミュレーター再起動をコメントアウト

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -67,38 +67,36 @@ jobs:
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp $DEV_PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
-      - name: Shutdown all simulators
-        run: xcrun simctl shutdown all
+      # - name: Shutdown all simulators
+      #   run: xcrun simctl shutdown all
   
-      - name: Erase all simulators
-        run: xcrun simctl erase all
+      # - name: Erase all simulators
+      #   run: xcrun simctl erase all
   
-      - name: Boot simulator (iPhone 15, iOS 17.2)
-        run: |
-          xcrun simctl boot "iPhone 15" || echo "Simulator already booted"
-          # Custom timeout handling
-          for i in {1..60}; do
-            if xcrun simctl bootstatus "iPhone 15" -b; then
-              echo "Simulator booted successfully."
-              break
-            fi
-            echo "Waiting for simulator to boot..."
-            sleep 5
-          done
+      # - name: Boot simulator (iPhone 15, iOS 17.2)
+      #   run: |
+      #     xcrun simctl boot "iPhone 15" || echo "Simulator already booted"
+      #     # Custom timeout handling
+      #     for i in {1..60}; do
+      #       if xcrun simctl bootstatus "iPhone 15" -b; then
+      #         echo "Simulator booted successfully."
+      #         break
+      #       fi
+      #       echo "Waiting for simulator to boot..."
+      #       sleep 5
+      #     done
 
       - name: UnitTests
-        #run: xcodebuild test -project ArigatouApp.xcodeproj -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,id=00008110-000664DA0EA0401E,OS=17.4.1' -allowProvisioningUpdates
-        #run: xcodebuild test -workspace ArigatouApp.xcworkspace -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15,OS=15.3.0'
         run: xcodebuild test -workspace ArigatouApp.xcworkspace -scheme ArigatouApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2'
 
-      - name: Clean Derived Data
-        run: rm -rf ~/Library/Developer/Xcode/DerivedData
+      # - name: Clean Derived Data
+      #   run: rm -rf ~/Library/Developer/Xcode/DerivedData
 
-      - name: Clean Xcode Caches
-        run: rm -rf ~/Library/Caches/com.apple.dt.Xcode
+      # - name: Clean Xcode Caches
+      #   run: rm -rf ~/Library/Caches/com.apple.dt.Xcode
 
-      - name: Clean CoreSimulator 
-        run: rm -rf ~/Library/Developer/CoreSimulator
+      # - name: Clean CoreSimulator 
+      #   run: rm -rf ~/Library/Developer/CoreSimulator
 
       - name: Save test results
         if: failure()

--- a/ArigatouApp/Model/DateManager.swift
+++ b/ArigatouApp/Model/DateManager.swift
@@ -13,26 +13,33 @@ class DateManager {
     private let calendar: Calendar
     private let timeZone: TimeZone
     private let locale: Locale
-    private let dateFormatter = DateFormatter()
+    
     
     private init() {
         self.calendar = Calendar(identifier: .gregorian)
         self.timeZone = TimeZone(identifier: "Asia/Tokyo")!
         self.locale = Locale(identifier: "ja_JP")
-        
-        dateFormatter.calendar = calendar
-        dateFormatter.timeZone = timeZone
-        dateFormatter.locale = locale
-        dateFormatter.dateFormat = "yyyy-MM-dd"
     }
     
     /// 指定されたDate型の日付を文字列にフォーマットして返す
     func currentDateString(date: Date = Date()) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = calendar
+        dateFormatter.timeZone = timeZone
+        dateFormatter.locale = locale
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
         return dateFormatter.string(from: date)
     }
     
     /// 指定された文字列の日付をDate型にフォーマットして返す
     func currentDate(_ dateString: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = calendar
+        dateFormatter.timeZone = timeZone
+        dateFormatter.locale = locale
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
         return dateFormatter.date(from: dateString)
     }
     
@@ -51,9 +58,13 @@ class DateManager {
     }
     
     func currentMonthString(date: Date = Date()) -> String {
-        dateFormatter.dateFormat = "yyyy-MM"
+        let monthFormatter = DateFormatter()
+        monthFormatter.calendar = calendar
+        monthFormatter.timeZone = timeZone
+        monthFormatter.locale = locale
+        monthFormatter.dateFormat = "yyyy-MM"
         
-        return dateFormatter.string(from: date)
+        return monthFormatter.string(from: date)
     }
     
 }


### PR DESCRIPTION
・DateFormatterがスレッドセーフでないため、CI実行中に設定が上書きされていたっぽい→対応
・CIが１時間かかるようになった→シミュレーターの再起動などをコメントアウトしてみる