### PR TITLE
スクリプト追加

### DIFF
--- a/ci_post_clone.sh
+++ b/ci_post_clone.sh
@@ -1,0 +1,4 @@
+# !/bin/sh
+
+brew install cocoapods
+pod install


### PR DESCRIPTION
毎回xcode-cloudeでエラー出てた事に気づいた

以下を参考にルートにスクリプトを配置
https://forums-developer-apple-com.translate.goog/forums/thread/720137?_x_tr_sl=en&_x_tr_tl=ja&_x_tr_hl=ja&_x_tr_pto=sc

cocoapodsをインストールする